### PR TITLE
Less layers in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM circleci/node:6
 
+RUN sudo apt-get update && sudo apt-get install -y \
+  awscli \
+  postgresql-client
+
 RUN sudo npm install -g junit-merge
-
-RUN sudo apt-get update && sudo apt-get install -y awscli
-
-RUN sudo apt-get install postgresql-client


### PR DESCRIPTION
* Combined `apt-get install` lines into one, to avoid additional layers in the Dockerfile. Best practice is to [minimize the number of layers.](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#minimize-the-number-of-layers)
* Moved `npm install` to the bottom.  No reason really, it just feels like a good convention to do system-level stuff (apt-get) first and then node packages afterward, since the `npm install` may rely on some things (like C compiler) that are impacted by apt-get installs